### PR TITLE
Set request's cors mode based on payload's object type

### DIFF
--- a/index.html
+++ b/index.html
@@ -447,6 +447,7 @@ partial interface <dfn id="WorkerNavigator">WorkerNavigator</dfn> {
               object's byte stream (<var>transmittedData</var>) and MIME type
               (<var>mimeType</var>).
             </li>
+            <li>Let <var>corsMode</var> be set to "<code>cors</code>" if object's type is is <code>Blob</code> and "<code>no-cors</code>" otherwise.</li>
             <li>Let <var>headerList</var> be null.</li>
           </ul>
         </li>
@@ -492,7 +493,7 @@ partial interface <dfn id="WorkerNavigator">WorkerNavigator</dfn> {
             <dt>
               <a>mode</a>
             </dt>
-            <dd><i>CORS</i></dd>
+            <dd><var>corsMode</var></dd>
             <dt>
               <a>credentials mode</a>
             </dt>


### PR DESCRIPTION
After a thorough scrub through Fetch with @toddreifsteck, I believe this should address #32. For motivation on this change see https://github.com/w3c/beacon/issues/32#issuecomment-228825553 - in particular, the comment about image beacons and chained redirects.

@toddreifsteck @annevk ptal and review. Any other edge cases we need to cover here?