### PR TITLE
remove referrer resource

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,16 +201,6 @@
             <li><dfn data-cite="DOM#concept-document">document</dfn></li>
           </ul>
         </dd>
-        <dt>HTML52</dt>
-        <dd>
-          <p>The following terms are defined in the HTML 5.2 specification:
-          [[!HTML52]]</p>
-          <ul>
-            <li><dfn id='referrer-source'><a href=
-            "https://www.w3.org/TR/html52/infrastructure.html#referrer-source">referrer
-            source</a></dfn></li>
-          </ul>
-        </dd>
         <dt>HTML</dt>
         <dd>
           <p>The following terms are defined in the HTML specification:
@@ -400,12 +390,6 @@
         <li>
           <p>Set <var>origin</var> to the <a>entry settings object</a>'s
           <a href="#resource-origin">origin</a>.</p>
-        </li>
-        <li>
-          <p>Set <var>referrer</var> to the <a>entry settings object</a>'s'
-          <a>referrer source</a>'s URL if <a>entry settings object</a>'s
-          <a>referrer source</a> is a <a>document</a>, and <a>entry settings
-          object</a>'s <a>referrer source</a> otherwise</p>
         </li>
         <li>
           <p>Set <var>parsedUrl</var> to the result of the <a>URL parser</a>

--- a/index.html
+++ b/index.html
@@ -242,8 +242,6 @@
             <li>request <dfn data-cite="FETCH#keep-alive-flag">keep-alive
             flag</dfn></li>
             <li>request <dfn data-cite=
-            "FETCH#concept-request-referrer">referrer</dfn></li>
-            <li>request <dfn data-cite=
             "FETCH#concept-request-body">body</dfn></li>
             <li>request <dfn data-cite=
             "FETCH#concept-request-mode">mode</dfn></li>
@@ -454,10 +452,6 @@
               <dt>
                 <a href="#request-origin">origin</a>
               </dt>
-              <dt>
-                <a>referrer</a>
-              </dt>
-              <dd><var>referrer</var></dd>
               <dt>
                 <a>keep-alive flag</a>
               </dt>


### PR DESCRIPTION
To fix #51 .


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/siusin/beacon/remove-referrer-source.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/beacon/eb050e2...siusin:08331ca.html)