### PR TITLE
Add conformance section

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,6 @@
     that such requests are still processed and delivered to destination.</p>
   </section>
   <section id='sotd'></section>
-  <section id='conformance'></section>
   <section id="introduction" class='informative'>
     <h2>Introduction</h2>
     <p>Web applications often need to issue requests that report events, state
@@ -168,16 +167,9 @@
       </li>
     </ul>
   </section>
-  <section>
-    <h2>Conformance requirements</h2>
-    <p>All diagrams, examples, and notes in this specification are
-    non-normative, as are all sections explicitly marked non-normative.
-    Everything else in this specification is normative.</p>
-    <p>The key words "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT",
-    "RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this
-    document are to be interpreted as described in [[!RFC2119]]. For
-    readability, these words do not appear in all uppercase letters in this
-    specification.</p>
+  <section id='conformance'>
+    <p>For readability, these words do not appear in all uppercase letters in
+    this specification.</p>
     <p>Requirements phrased in the imperative as part of algorithms (such as
     "strip any leading space characters" or "return false and abort these
     steps") are to be interpreted with the meaning of the key word ("must",

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
     that such requests are still processed and delivered to destination.</p>
   </section>
   <section id='sotd'></section>
+  <section id='conformance'></section>
   <section id="introduction" class='informative'>
     <h2>Introduction</h2>
     <p>Web applications often need to issue requests that report events, state


### PR DESCRIPTION
Fixes "Normative references in informative sections are not allowed" warning messages reported by ReSpec.

These warnings appeared because Respec assumes that the spec is informative-only in the absence of a conformance section, see discussion in:
https://github.com/w3c/respec/issues/2580


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/beacon/pull/65.html" title="Last updated on Nov 21, 2019, 10:23 AM UTC (cfded1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/beacon/65/35a86f6...tidoust:cfded1e.html" title="Last updated on Nov 21, 2019, 10:23 AM UTC (cfded1e)">Diff</a>