### PR TITLE
Set the keepalive flag when extracting the body

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,9 +394,9 @@
         <li>
           <p>If <var>data</var> is not <code>null</code>:</p>
           <ol>
-            <li>
-              <a>Extract</a> object's byte stream (<var>transmittedData</var>)
-              and content type (<var>contentType</var>).
+            <li>Set <var>transmittedData</var> and <var>contentType</var> to the
+              result of <a data-lt="extract">extracting</a> <var>data</var>'s
+              byte stream with the <var>keepalive flag</var> set.
             </li>
             <li>If the amount of data that can be queued to be sent by
               <a href="#concept-keep-alive-flag">keepalive</a> enabled requests


### PR DESCRIPTION
Setting the keepalive flag is necessary so that the fetch algorithm will
throw a TypeError if a ReadableStream is passed in. See
https://crbug.com/973659.

The requirement to throw is already tested by the web platform tests:
https://wpt.fyi/results/beacon/beacon-readablestream.window.html.

Also rephrase the extract step to match the way it is used in the Fetch
Standard.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ricea/beacon/pull/66.html" title="Last updated on Jan 30, 2020, 11:54 AM UTC (1b4c28c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/beacon/66/09c5ff9...ricea:1b4c28c.html" title="Last updated on Jan 30, 2020, 11:54 AM UTC (1b4c28c)">Diff</a>